### PR TITLE
Pass commands to su as single arguments

### DIFF
--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -25,7 +25,7 @@ def parse_bool(value):
 def adb_read_file(path):
     print('Reading file', path, file=sys.stderr)
 
-    process = subprocess.Popen(['adb', 'exec-out', 'su', '-c', 'cat', path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(['adb', 'exec-out', 'su', '-c', 'cat "{}"'.format(path)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = process.communicate()
 
     if stderr:
@@ -44,7 +44,7 @@ def adb_read_file(path):
 
 def check_root():
     try:
-        output = subprocess.check_output(['adb', 'exec-out', 'su', '-c', 'printf', 'TEST'])
+        output = subprocess.check_output(['adb', 'exec-out', 'su', '-c', 'printf TEST'])
         return output.strip() == b'TEST'
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
With my setup (Kubuntu 17.10 and Lineage 14.1), when the script calls `su -c printf TEST` on the device, it ends up telling `su` to run `printf` as user `TEST`, as opposed to telling it to run `printf TEST`, and passing no user argument. Same deal with the `cat` command invoked in `adb_read_file()`.

This change makes it so that when `su` is invoked on device, the argument to `-c` is passed as one thing. The `cat` command also quotes the path to prevent problems with spaces in paths, although I don't expect those to happen often on Android. 

I haven't tested this on Windows, or other *nix platforms. I assume the script works somewhere as-is, but I speculate these changes shouldn't break it. 

Resolves #2 