### PR TITLE
Add steam authenticator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Requires Python 3.6+ and a **rooted** Android phone.
 
     usage: extract_otp_tokens.py [-h] [--andotp] [--no-authy] [--no-duo]
                                  [--no-freeotp] [--no-google-authenticator]
-                                 [--no-microsoft-authenticator] [--data DATA]
-                                 [--show-uri [SHOW_URI]] [--show-qr [SHOW_QR]]
+                                 [--no-microsoft-authenticator] [--no-steam-authenticator]
+                                 [--data DATA] [--no-show-uri] [--show-qr]
                                  [--andotp-backup ANDOTP_BACKUP]
 
     Extracts TOTP secrets from a rooted Android phone.
@@ -33,10 +33,12 @@ Requires Python 3.6+ and a **rooted** Android phone.
                             no Google Authenticator codes (default: False)
       --no-microsoft-authenticator
                             no Microsoft Authenticator codes (default: False)
+      --no-steam-authenticator
+                            no Steam Authenticator codes (default: False)
+                            
       --data DATA           path to the app data folder (default: /data/data)
-      --show-uri [SHOW_URI]
-                            prints the accounts as otpauth:// URIs (default: True)
-      --show-qr [SHOW_QR]   displays the accounts as a local webpage with
+      --no-show-uri         disables printing the accounts as otpauth:// URIs
+      --show-qr             displays the accounts as a local webpage with
                             scannable QR codes (default: False)
       --andotp-backup ANDOTP_BACKUP
                             saves the accounts as an AndOTP backup file (default:

--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -23,13 +23,13 @@ def adb_list_dir(path):
             args=['adb', 'shell', f'su -c ls {shlex.quote(path)}'],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT
             )
-    output = process.communicate()
-    output = str(output[0], 'utf-8').strip(), output[1]
-    if 'No suck file or directory' in output[0]:
+    message, err = process.communicate()
+    message = str(message, 'utf-8').strip()
+    if 'No such file or directory' in message:
         raise FileNotFoundError(path)
-    elif output[1] is not None:
-        raise IOError(output[0])
-    return [filename.strip() for filename in output[0].split('\n')] # a list of filenames
+    elif err is not None:
+        raise IOError(message)
+    return [filename.strip() for filename in message.split('\n')] # a list of filenames
 
 
 def adb_read_file(path):

--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -227,7 +227,7 @@ def read_steam_authenticator_accounts(data_root):
 
 def export_andotp(accounts):
     return json.dumps([{
-        'secret': a.secret if not a.name.startswith('steam-') else str(a.secret),
+        'secret': a.secret if not a.name.startswith('steam-') else str(a.secret, 'utf-8'),
         'label': a.name,
         'digits': a.digits,
         'period': a.period,

--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -20,7 +20,7 @@ Account = namedtuple('Account', ['name', 'digits', 'period', 'secret'])
 
 def adb_list_dir(path):
     process = subprocess.Popen(
-            args=['adb', 'shell', f'su -c ls', path],
+            args=['adb', 'shell', f'su -c ls {shlex.quote(path)}'],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT
             )
     output = process.communicate()


### PR DESCRIPTION
This branch adds support for extracting and generating andOTP backups for steam authenticator codes.
Since the generation of steam codes is a slightly modified one, I had to denote the codes being steam codes by inserting 'steam-' at the beginning of their names. Ideally I think that adding an 'issuer' value to each code is a better solution, but I'm not familiar enough with any of the other authenticators to get it working properly.