### PR TITLE
Avoid exceptions for accounts without a name

### DIFF
--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -54,8 +54,6 @@ class OTPAccount:
         if self.issuer:
             params['issuer'] = self.issuer
 
-        name = self.name if self.name is not None else "Unknown"
-
         if prepend_issuer and self.issuer:
             name = f'{self.issuer}: {self.name}'
 
@@ -257,9 +255,10 @@ def read_google_authenticator_accounts(data_root):
     try:
         connection = sqlite3.connect(temp_handle.name)
         cursor = connection.cursor()
-        cursor.execute('SELECT original_name, secret, counter, type, issuer FROM accounts;')
+        cursor.execute('SELECT email, original_name, secret, counter, type, issuer FROM accounts;')
 
-        for name, secret, counter, type, issuer in cursor.fetchall():
+        for email, name, secret, counter, type, issuer in cursor.fetchall():
+            name = name if name is not None else email
             if type == 0:
                 yield TOTPAccount(name, secret, issuer=issuer)
             elif type == 1:

--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -54,7 +54,7 @@ class OTPAccount:
         if self.issuer:
             params['issuer'] = self.issuer
 
-        name = self.name
+        name = self.name if self.name is not None else "Unknown"
 
         if prepend_issuer and self.issuer:
             name = f'{self.issuer}: {self.name}'


### PR DESCRIPTION
These were probably generated by an older version of Google Authenticator on my device.