### PR TITLE
Remove account_type from MS Authenticator to fix exporting corporate accounts

### DIFF
--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -337,7 +337,7 @@ def read_microsoft_authenticator_accounts(adb, data_root):
     try:
         with open_remote_sqlite_database(adb, data_root/'com.azure.authenticator/databases/PhoneFactor') as connection:
             cursor = connection.cursor()
-            cursor.execute('SELECT name, oath_secret_key FROM accounts WHERE account_type=0;')
+            cursor.execute('SELECT name, oath_secret_key FROM accounts;')
 
             for name, secret in cursor.fetchall():
                 yield TOTPAccount(name, secret)


### PR DESCRIPTION
This removes the account_type filter from the Microsoft Authenticator search to fix an issue when exporting corporate tokens which aren't always of type 0