### PR TITLE
Switch to pycryptodomex

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Many OTP apps don't support exporting their OTP secrets. Switching apps would re
 
  - Make sure Python3 is installed
    - on Mac, you can do so with `brew install python3` (provided [HomeBrew](https://brew.sh/) is already installed)
+ - Install pycryptodomex with `pip install pycryptodomex`
  - Clone the repo or just download [the main script](https://raw.githubusercontent.com/puddly/android-otp-extractor/master/extract_otp_tokens.py)
  - Make it executable with `chmod +x extract_otp_tokens.py`
 

--- a/extract_otp_tokens.py
+++ b/extract_otp_tokens.py
@@ -371,7 +371,7 @@ def read_andotp_accounts(adb, data_root):
 
     if 'encrypted' in allowed_backup_broadcasts:
         try:
-            from Crypto.Cipher import AES
+            from Cryptodome.Cipher import AES
         except:
             logger.error('Reading encrypted AndOTP backups requires PyCryptodome')
             return


### PR DESCRIPTION
This fixes
````
Enter the AndOTP backup password: 
Traceback (most recent call last):
  File "./extract_otp_tokens.py", line 668, in <module>
    new = list(function(adb, args.data))
  File "./extract_otp_tokens.py", line 451, in read_andotp_accounts
    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
AttributeError: module 'Crypto.Cipher.AES' has no attribute 'MODE_GCM'
````