### PR TITLE
Support Battle.net authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Many OTP apps don't support exporting or backing up their OTP secrets. Switching
  - Steam Authenticator
  - AndOTP (when backups are enabled)
  - Aegis
+ - Battle.net Authenticator
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='android-otp-extractor',
-    version='1.0.5',
+    version='1.0.6',
     description='Extracts and exports OTP secrets from most Android OTP apps',
 
     long_description=(pathlib.Path(__file__).parent / 'README.md').read_text(),

--- a/src/android_otp_extractor/apps.py
+++ b/src/android_otp_extractor/apps.py
@@ -312,6 +312,24 @@ def read_steam_authenticator_accounts(adb):
         yield SteamAccount(account_json['account_name'], secret)
 
 
+@supported_app('Battle.net Authenticator')
+def read_battle_net_authenticator_accounts(adb):
+    try:
+        f = adb.read_file(adb.data_root/'com.blizzard.bma/shared_prefs/com.blizzard.bma.AUTH_STORE.xml')
+    except FileNotFoundError:
+        return
+
+    encoded_hash = ElementTree.parse(f).find('.//map/string[@name="com.blizzard.bma.AUTH_STORE.HASH"]').text
+
+    key = bytes.fromhex('398e27fc50276a656065b0e525f4c06c04c61075286b8e7aeda59da9813b5dd6c80d2fb38068773fa59ba47c17ca6c6479015c1d5b8b8f6b9a')
+    decoded_hash = bytes([a ^ b for a, b in zip(bytes.fromhex(encoded_hash), key)]).decode('ascii')
+
+    secret = bytes.fromhex(decoded_hash[:40])
+    serial = decoded_hash[40:]
+
+    yield TOTPAccount(f"Battle.net {serial}", issuer="Battle.net", secret=secret, digits=8, period=30)
+
+
 @supported_app('Aegis')
 def read_aegis_accounts(adb):
     try:

--- a/src/android_otp_extractor/apps.py
+++ b/src/android_otp_extractor/apps.py
@@ -319,7 +319,7 @@ def read_battle_net_authenticator_accounts(adb):
     except FileNotFoundError:
         return
 
-    encoded_hash = ElementTree.parse(f).find('.//map/string[@name="com.blizzard.bma.AUTH_STORE.HASH"]').text
+    encoded_hash = ElementTree.parse(f).find('.//string[@name="com.blizzard.bma.AUTH_STORE.HASH"]').text
 
     key = bytes.fromhex('398e27fc50276a656065b0e525f4c06c04c61075286b8e7aeda59da9813b5dd6c80d2fb38068773fa59ba47c17ca6c6479015c1d5b8b8f6b9a')
     decoded_hash = bytes([a ^ b for a, b in zip(bytes.fromhex(encoded_hash), key)]).decode('ascii')


### PR DESCRIPTION
I can't get the app running on my phone to actually test the changes. @p1r473, can you give it a try?

If you have Git:
```console
$ pip install --upgrade git+https://github.com/puddly/android-otp-extractor.git@puddly/battle.net-authenticator
```

If you don't:

```console
$ pip install --upgrade https://github.com/puddly/android-otp-extractor/archive/refs/heads/puddly/battle.net-authenticator.zip
```

