### PR TITLE
Support Authenticator Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Many OTP apps don't support exporting or backing up their OTP secrets. Switching
  - AndOTP (when backups are enabled)
  - Aegis
  - Battle.net Authenticator
+ - Authenticator Plus
 
 ## Installation
 
@@ -27,20 +28,20 @@ Requires Python 3.6+ and a **rooted** Android phone.
 
 ```
 usage: python -m android_otp_extractor [-h]
-                                       [--include {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,aegis} | --exclude {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,aegis}]
+                                       [--include {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,battlenet_authenticator,aegis,authenticator_plus} | --exclude {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,battlenet_authenticator,aegis,authenticator_plus}]
                                        [--data DATA]
                                        [--busybox-path BUSYBOX_PATH]
                                        [--no-show-qr] [--prepend-issuer]
                                        [--andotp-backup ANDOTP_BACKUP] [-v]
 
-Extracts OTP secrets from a rooted Android phone.
+Extracts TOTP secrets from a rooted Android phone.
 
 optional arguments:
   -h, --help            show this help message and exit
-  --include {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,aegis}
+  --include {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,battlenet_authenticator,aegis,authenticator_plus}
                         only export secrets from this app. Can be specified
                         multiple times. (default: None)
-  --exclude {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,aegis}
+  --exclude {authy,freeotp,freeotp_plus,duo,google_authenticator,microsoft_authenticator,andotp,steam_authenticator,battlenet_authenticator,aegis,authenticator_plus}
                         do not export secrets from this app. Can be specified
                         multiple times. (default: None)
   --data DATA           path to the app data folder (default:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='android-otp-extractor',
-    version='1.0.6',
+    version='1.0.7',
     description='Extracts and exports OTP secrets from most Android OTP apps',
 
     long_description=(pathlib.Path(__file__).parent / 'README.md').read_text(),

--- a/src/android_otp_extractor/apps.py
+++ b/src/android_otp_extractor/apps.py
@@ -14,7 +14,7 @@ import cryptography
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 
-from .contrib import open_remote_sqlite_database
+from .contrib import open_remote_sqlite_database, escape_sql_string
 from .otp import TOTPAccount, HOTPAccount, SteamAccount, lenient_base32_decode
 
 
@@ -360,6 +360,48 @@ def read_aegis_accounts(adb):
             yield SteamAccount(entry['name'], issuer=entry['issuer'], secret=secret)
         else:
             LOGGER.warning('Unknown Aegis account type: %s', entry['type'])
+
+
+@supported_app('Authenticator Plus')
+def read_authenticator_plus_accounts(adb):
+    try:
+        f = adb.read_file(adb.data_root/'com.mufri.authenticatorplus/databases/databases')
+    except FileNotFoundError:
+        return
+
+    try:
+        from pysqlcipher3 import dbapi2 as sqlcipher_sqlite
+    except ImportError:
+        LOGGER.error("Decrypting Authenticator Plus databases requires the `pysqlcipher3` Python package")
+        return
+
+    with open_remote_sqlite_database(
+        adb, adb.data_root/'com.mufri.authenticatorplus/databases/databases',
+        sqlite3=sqlcipher_sqlite
+    ) as connection:
+        cursor = connection.cursor()
+
+        master_password = getpass.getpass('Enter the Authenticator Plus master password: ')
+
+        # XXX: This is intentional. You can't parameterize PRAGMA queries.
+        cursor.execute(f"PRAGMA key = {escape_sql_string(master_password)};")
+        cursor.execute("PRAGMA cipher_page_size = 1024;")
+        cursor.execute("PRAGMA kdf_iter = 64000;")
+        cursor.execute("PRAGMA cipher_hmac_algorithm = HMAC_SHA1;")
+        cursor.execute("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1;")
+
+        cursor.execute('SELECT * FROM accounts;')
+
+        for row in cursor.fetchall():
+            secret = lenient_base32_decode(row['secret'])
+
+            if row['type'] == 0:
+                yield TOTPAccount(row['email'], issuer=row['issuer'], secret=secret)
+            elif row['type'] == 1:
+                yield HOTPAccount(row['email'], issuer=row['issuer'], secret=secret, counter=row['counter'])
+            else:
+                LOGGER.warning("Unknown account type %s: %s", row['type'], dict(row))
+
 
 
 def read_accounts(adb, apps):

--- a/src/android_otp_extractor/apps.py
+++ b/src/android_otp_extractor/apps.py
@@ -30,7 +30,7 @@ def supported_app(name):
     Simple decorator to populate the SUPPORTED_APPS list
     '''
 
-    simple_name = name.lower().replace('+', '_plus').replace(' ', '_')
+    simple_name = name.lower().replace('+', '_plus').replace(' ', '_').replace('.', '')
 
     def inner(extractor):
         SUPPORTED_APPS.append(SupportedApp(name, simple_name, extractor))

--- a/src/android_otp_extractor/contrib.py
+++ b/src/android_otp_extractor/contrib.py
@@ -9,9 +9,29 @@ from pathlib import PurePosixPath, Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from urllib.request import pathname2url
 
+# https://github.com/elouajib/sqlescapy/blob/master/sqlescapy/sqlescape.py
+SQL_BACKSLASHED_CHARS = str.maketrans({
+    "\x00": "\\0",
+    "\x08": "\\b",
+    "\x09": "\\t",
+    "\x1a": "\\z",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\\": "\\\\",
+    "%": "\\%",
+    "'": "''",
+})
+
+def escape_sql_string(text):
+    """
+    SQLite cannot handle parameterized PRAGMA queries so manual string escaping must be used.
+    """
+
+    return "'" + text.translate(SQL_BACKSLASHED_CHARS) + "'"
+
 
 @contextlib.contextmanager
-def open_remote_sqlite_database(adb, database):
+def open_remote_sqlite_database(adb, database, *, sqlite3=sqlite3):
     database = PurePosixPath(database)
 
     with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Some untested things:

 - Does Authenticator Plus encode its secrets? Are they always base-32?
 - Only account type `0` exists in the sample db (thanks @p1r473). I'm assuming `1` is HTOP, with a counter.
