### PR TITLE
feat: Allow direct calls from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,26 @@ Many OTP apps don't support exporting or backing up their OTP secrets. Switching
 
 ## Installation
 
-```bash
-$ pip install git+https://github.com/puddly/android-otp-extractor
-$ python -m android_otp_extractor
-```
+1. Install with pipx
+
+   ```bash
+   pipx install git+https://github.com/puddly/android-otp-extractor
+   android-otp-extractor --help
+   ```
+
+1. Install as a Python module
+
+   We suggest that you install this in a temporary directory instead of your HOME directory.
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install git+https://github.com/puddly/android-otp-extractor
+   # Run directly
+   android-otp-extractor --help
+   # Run as a module
+   python -m android_otp_extractor --help
+   ```
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,10 @@ setup(
         'Bug Reports': 'https://github.com/puddly/android-otp-extractor/issues',
         'Source': 'https://github.com/puddly/android-otp-extractor/',
     },
+
+    entry_points={
+        'console_scripts': [
+            'android-otp-extractor=android_otp_extractor.cli:main',
+        ],
+    },
 )


### PR DESCRIPTION
Added a `console_script` entry in `setup.py` to allow the app to be called directly from the terminal.

This also makes it more portable with `pipx`.